### PR TITLE
Code prettify

### DIFF
--- a/_posts/2022-01-08-objc-defer.md
+++ b/_posts/2022-01-08-objc-defer.md
@@ -6,6 +6,8 @@ tags: [💻]
 description: Reducing code duplication and improving locality in Objective-C with macros.
 ---
 
+_UPDATE: predictably, [Peter Steinberger and Matej Bukovinski beat me to this](https://pspdfkit.com/blog/2017/even-swiftier-objective-c/), and [Justin Spahr-Summers was ahead of them](https://github.com/jspahrsummers/libextobjc/blob/bdec77056a38a52bc8f30a19cec52d66a70e7bf6/extobjc/EXTScope.h#L12-L33)._
+
 This all started because I was complaining about some uninitialized pointer value causing me grief[^mmap] and someone (explicitly trolling) said they always check pointers using:
 
 ``` c
@@ -43,7 +45,7 @@ This reduces duplication, but has worse locality. I don't love it, but I feel li
 
 Really what I want is something like [Swift's `defer`](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID532):
 
-``` c
+``` objective_c
 int fds[2] = { -1, -1}; 
 pipe(fds);
 defer ^{
@@ -60,7 +62,7 @@ if (write(fds[0], pointer_to_check, sizeof(intptr_t)) == -1) {
 
 Turned out it's not too heinous to hack together. Here it is:
 
-``` c
+``` objective_c
 static void __defer_cleanup(void (^*pBlock)(void)) { (*pBlock)(); }
 #define __defer_tokenpaste(prefix, suffix) prefix ## suffix
 #define __defer_blockname(nonce) __defer_tokenpaste(__defer_, nonce)
@@ -79,8 +81,6 @@ __attribute__((__unused__, \
                __cleanup__(__defer_cleanup) \
 )) = 
 ```
-
-Update: predictably, [Peter Steinberger and Matej Bukovinski beat me to this](https://pspdfkit.com/blog/2017/even-swiftier-objective-c/), and [Justin Spahr-Summers was ahead of them](https://github.com/jspahrsummers/libextobjc/blob/bdec77056a38a52bc8f30a19cec52d66a70e7bf6/extobjc/EXTScope.h#L12-L33).
 
 [^mmap]: as appealing as its promise is, `mmap` is bad and you should never use it unless you truly need garbage collected shared memory between processes, in which case your life already sucks and I'm sorry. `pread` and `pwrite` will set `errno` instead of crashing your process and are not nearly as slow as you think; you should stick with them until you can measure otherwise, at which point you should investigate doing your own paging because as I just said `mmap` is dangerous and bad.
 [^mincore]: If you have a problem with wild pointers then you _also_ have much bigger problems that you should solve first. If you're just hacking away on code that will never run on someone else's computer you should try [`mincore`](https://man7.org/linux/man-pages/man2/mincore.2.html) or [`mach_vm_read`](https://developer.apple.com/documentation/kernel/1402405-mach_vm_read).

--- a/_posts/2022-01-08-objc-defer.md
+++ b/_posts/2022-01-08-objc-defer.md
@@ -69,16 +69,16 @@ static void __defer_cleanup(void (^*pBlock)(void)) { (*pBlock)(); }
 
 /* Declare a local block variable that contains the cleanup code.
  * It has three attributes:
- *   __unused__: because you should NEVER touch this local yourself
- *   __deprecated__: because you should NEVER touch this local yourself
- *   __cleanup__: to get its pointer passed to __defer_cleanup (above)
+ *   unused: because you should NEVER touch this local yourself
+ *   deprecated: because you should NEVER touch this local yourself
+ *   cleanup: to get its pointer passed to __defer_cleanup (above)
  *                when the scope ends
  */
 #define defer \
 void (^ __defer_blockname(__LINE__))(void) \
-__attribute__((__unused__, \
+__attribute__((unused, \
                deprecated("hands off!"), \
-               __cleanup__(__defer_cleanup) \
+               cleanup(__defer_cleanup) \
 )) = 
 ```
 

--- a/_posts/2022-08-17-what-is-mmt.md
+++ b/_posts/2022-08-17-what-is-mmt.md
@@ -6,7 +6,7 @@ tags: [💵]
 description: "What gives fiat currencies value, and what can we do with them?"
 ---
 
-Modern Monetary Theory (MMT) is a framework for thinking about the relationship between the issuer of a [fiat currency](https://en.wikipedia.org/wiki/Fiat_money) and the economy it denominates.
+Modern Monetary Theory (MMT) is a framework for thinking about the relationship between the issuer of a fiat currency and the economy it denominates.
 
 It has two basic premises:
 
@@ -14,9 +14,10 @@ It has two basic premises:
 
 More formally, _the fundamental value of a dollar is non-zero because the market for dollars is propped up on the demand side by taxes._
 
-Within the United States, support for the dollar also extends to debts thanks to §31 U.S.C. 5103:
+Within the United States, support for the dollar also extends to debts:
 
 > United States coins and currency [including Federal Reserve notes and circulating notes of Federal Reserve Banks and national banks] are legal tender for all debts, public charges, taxes, and dues.
+> <cite>– §31 U.S.C. 5103</cite>
 
 In normal conditions[^hyperinflation] this creates a virtuous cycle for the currency issuer; since everyone needs dollars for their debts and taxes, employers are incentivised to pay their workers in dollars, which in turn encourages them to accept dollars for their goods and services. The ubiquity of the dollar in the economy—or, put another way, people's faith that it will be useful for settling transactions—is what gives it value beyond the baseline set by taxes.
 
@@ -35,7 +36,7 @@ The government has many options for increasing the money supply, including spend
 <!--
 > We can, and must, tax the rich. But not because we can't afford to do anything without them. We shoudl tax billionaires to rebalance the distribution of wealth and income and to protect the health of our democracy.
 > 
-> —The Deficit Myth, p12
+> — The Deficit Myth, p12
 -->
 
 This premise puts the lie to the most common complaint against public spending: "how will you pay for it?" Through the lens of MMT, the government's budget _doesn't need to balance_. Running a deficit is not the same as overspending unless it sparks… 
@@ -43,8 +44,7 @@ This premise puts the lie to the most common complaint against public spending: 
 ## Inflation
 
 > At its core, MMT is about replacing an artificial (revenue) constraint with a real (inflation) constraint
-
-— [<cite>The Deficit Myth</cite>](https://stephaniekelton.com/book/), p72
+> <cite>– [The Deficit Myth](https://stephaniekelton.com/book/), p72</cite>
 
 In an otherwise static system, we can view inflation as the result of a government spending more than it collects in taxes. From the perspective of a "dollar market", excess spending by the government creates a glut on the supply side, diluting the currency's value.
 
@@ -77,8 +77,7 @@ This post is mostly written in terms of US dollars, but the framework applies ju
 If you found this interesting, check out [this talk by Stephanie Kelton](https://www.youtube.com/watch?v=FATQ0Yf0Fhc). She also wrote [The Deficit Myth](https://stephaniekelton.com/book/), which includes this closing quote:
 
 > As long as there is plenty, poverty is evil. Government belongs wherever evil needs an adversary and there are people in distress.
-> 
-> —John F. Kennedy
+> <cite>– John F. Kennedy</cite>
 
 [^hyperinflation]: The exception being periods of hyperinflation, during which locals will prefer to be paid in (or immediately trade their paycheck for) a more stable currency—usually the dollar—in the hope of preserving the buying power of a day's work. A relatively recent example of this can be found [in Venezuela](https://www.npr.org/transcripts/635519727).
 [^ransom]: So far: paying ransoms.

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -148,27 +148,70 @@ blockquote {
  */
 pre,
 code {
-  @include relative-font-size(0.9375);
   border: 1px solid $grey-color-light;
+}
+code,
+tt {
+  padding: .1em .2em;
+  margin: 0;
+  font-size: 85%;
+  background-color: rgba(175,184,193,0.2);
   border-radius: 3px;
-  background-color: #eef;
 }
 
-code {
-  padding: 1px 5px;
+code br,
+tt br {
+  display: none;
 }
 
+del code {
+  text-decoration: inherit;
+}
+
+pre code {
+  font-size: 100%;
+}
+
+.highlight {
+  margin-bottom: 16px;
+}
+
+.highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.highlight pre,
 pre {
-  padding: 8px 12px;
-  overflow-x: auto;
-
-  > code {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+  
+  >code {
+    padding: 0;
+    margin: 0;
+    word-break: normal;
+    white-space: pre;
+    background: transparent;
     border: 0;
-    padding-right: 0;
-    padding-left: 0;
   }
 }
 
+pre code,
+pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
 
 
 /**

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -144,11 +144,10 @@ blockquote blockquote blockquote {
 
 blockquote {
   color: $grey-color;
-  padding-left: $spacing-unit / 2;
+  padding: 0px $spacing-unit / 2;
   letter-spacing: -0.4px;
 
   float: left;
-  padding-right: 3em;
 
   > :last-child {
     margin-bottom: 0;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -128,20 +128,39 @@ a {
 /**
  * Blockquotes
  */
+
+blockquote {
+  border-left: 3px solid lighten(blue, 40%);
+}
+
+blockquote blockquote {
+  border-left: 3px solid lighten(green, 40%);
+  float: none;
+}
+
+blockquote blockquote blockquote {
+  border-left: 3px solid lighten(black, 40%);
+}
+
 blockquote {
   color: $grey-color;
-  border-left: 4px solid $grey-color-light;
   padding-left: $spacing-unit / 2;
-  @include relative-font-size(1.125);
-  letter-spacing: -1px;
-  font-style: italic;
+  letter-spacing: -0.4px;
+
+  float: left;
+  padding-right: 3em;
 
   > :last-child {
     margin-bottom: 0;
   }
 }
 
-
+cite {
+	display: block;
+  float: right;
+  color: lighten($grey-color, 20%);
+	font-style: italic;
+}
 
 /**
  * Code formatting

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -156,7 +156,7 @@ tt {
   margin: 0;
   font-size: 85%;
   background-color: rgba(175,184,193,0.2);
-  border-radius: 3px;
+  border-radius: 0.2em;
 }
 
 code br,

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -135,7 +135,7 @@ blockquote {
 
 blockquote blockquote {
   border-left: 3px solid lighten(green, 40%);
-  float: none;
+  float: none; // Cancel out the `float: right;` of the parent so the <cite> will locate correctly
 }
 
 blockquote blockquote blockquote {

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -1,71 +1,66 @@
-/**
- * Syntax highlighting styles
- */
-.highlight {
-  background: #fff;
-  @extend %vertical-rhythm;
-
-  .highlighter-rouge & {
-    background: #eef;
-  }
-
-  .c     { color: #998; font-style: italic } // Comment
-  .err   { color: #a61717; background-color: #e3d2d2 } // Error
-  .k     { font-weight: bold } // Keyword
-  .o     { font-weight: bold } // Operator
-  .cm    { color: #998; font-style: italic } // Comment.Multiline
-  .cp    { color: #999; font-weight: bold } // Comment.Preproc
-  .c1    { color: #998; font-style: italic } // Comment.Single
-  .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
-  .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-  .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-  .ge    { font-style: italic } // Generic.Emph
-  .gr    { color: #a00 } // Generic.Error
-  .gh    { color: #999 } // Generic.Heading
-  .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-  .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-  .go    { color: #888 } // Generic.Output
-  .gp    { color: #555 } // Generic.Prompt
-  .gs    { font-weight: bold } // Generic.Strong
-  .gu    { color: #aaa } // Generic.Subheading
-  .gt    { color: #a00 } // Generic.Traceback
-  .kc    { font-weight: bold } // Keyword.Constant
-  .kd    { font-weight: bold } // Keyword.Declaration
-  .kp    { font-weight: bold } // Keyword.Pseudo
-  .kr    { font-weight: bold } // Keyword.Reserved
-  .kt    { color: #458; font-weight: bold } // Keyword.Type
-  .m     { color: #099 } // Literal.Number
-  .s     { color: #d14 } // Literal.String
-  .na    { color: #008080 } // Name.Attribute
-  .nb    { color: #0086B3 } // Name.Builtin
-  .nc    { color: #458; font-weight: bold } // Name.Class
-  .no    { color: #008080 } // Name.Constant
-  .ni    { color: #800080 } // Name.Entity
-  .ne    { color: #900; font-weight: bold } // Name.Exception
-  .nf    { color: #900; font-weight: bold } // Name.Function
-  .nn    { color: #555 } // Name.Namespace
-  .nt    { color: #000080 } // Name.Tag
-  .nv    { color: #008080 } // Name.Variable
-  .ow    { font-weight: bold } // Operator.Word
-  .w     { color: #bbb } // Text.Whitespace
-  .mf    { color: #099 } // Literal.Number.Float
-  .mh    { color: #099 } // Literal.Number.Hex
-  .mi    { color: #099 } // Literal.Number.Integer
-  .mo    { color: #099 } // Literal.Number.Oct
-  .sb    { color: #d14 } // Literal.String.Backtick
-  .sc    { color: #d14 } // Literal.String.Char
-  .sd    { color: #d14 } // Literal.String.Doc
-  .s2    { color: #d14 } // Literal.String.Double
-  .se    { color: #d14 } // Literal.String.Escape
-  .sh    { color: #d14 } // Literal.String.Heredoc
-  .si    { color: #d14 } // Literal.String.Interpol
-  .sx    { color: #d14 } // Literal.String.Other
-  .sr    { color: #009926 } // Literal.String.Regex
-  .s1    { color: #d14 } // Literal.String.Single
-  .ss    { color: #990073 } // Literal.String.Symbol
-  .bp    { color: #999 } // Name.Builtin.Pseudo
-  .vc    { color: #008080 } // Name.Variable.Class
-  .vg    { color: #008080 } // Name.Variable.Global
-  .vi    { color: #008080 } // Name.Variable.Instance
-  .il    { color: #099 } // Literal.Number.Integer.Long
-}
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #008800; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .g { color: #2c2cff } /* Generic */
+.highlight .k { color: #2c2cff } /* Keyword */
+.highlight .x { background-color: #ffffe0 } /* Other */
+.highlight .ch { color: #008800; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #008800; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #008800; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #008800; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #008800; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #008800; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #2c2cff } /* Generic.Deleted */
+.highlight .ge { color: #008800 } /* Generic.Emph */
+.highlight .gr { color: #d30202 } /* Generic.Error */
+.highlight .gh { color: #2c2cff } /* Generic.Heading */
+.highlight .gi { color: #2c2cff } /* Generic.Inserted */
+.highlight .go { color: #2c2cff } /* Generic.Output */
+.highlight .gp { color: #2c2cff } /* Generic.Prompt */
+.highlight .gs { color: #2c2cff } /* Generic.Strong */
+.highlight .gu { color: #2c2cff } /* Generic.Subheading */
+.highlight .gt { color: #2c2cff } /* Generic.Traceback */
+.highlight .kc { color: #2c2cff; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #2c2cff } /* Keyword.Declaration */
+.highlight .kn { color: #2c2cff } /* Keyword.Namespace */
+.highlight .kp { color: #2c2cff } /* Keyword.Pseudo */
+.highlight .kr { color: #353580; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #2c2cff } /* Keyword.Type */
+.highlight .m { color: #2c8553; font-weight: bold } /* Literal.Number */
+.highlight .s { color: #800080 } /* Literal.String */
+.highlight .n { color: #2c2c2c }
+.highlight .nb { color: #2c2cff } /* Name.Builtin */
+.highlight .nf { color: #2c2c2c; font-weight: bold; font-style: italic } /* Name.Function */
+.highlight .nv { color: #2c2cff; font-weight: bold } /* Name.Variable */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #2c8553; font-weight: bold } /* Literal.Number.Bin */
+.highlight .mf { color: #2c8553; font-weight: bold } /* Literal.Number.Float */
+.highlight .mh { color: #2c8553; font-weight: bold } /* Literal.Number.Hex */
+.highlight .mi { color: #2c8553; font-weight: bold } /* Literal.Number.Integer */
+.highlight .mo { color: #2c8553; font-weight: bold } /* Literal.Number.Oct */
+.highlight .sa { color: #800080 } /* Literal.String.Affix */
+.highlight .sb { color: #800080 } /* Literal.String.Backtick */
+.highlight .sc { color: #800080 } /* Literal.String.Char */
+.highlight .dl { color: #800080 } /* Literal.String.Delimiter */
+.highlight .sd { color: #800080 } /* Literal.String.Doc */
+.highlight .s2 { color: #800080 } /* Literal.String.Double */
+.highlight .se { color: #800080 } /* Literal.String.Escape */
+.highlight .sh { color: #800080 } /* Literal.String.Heredoc */
+.highlight .si { color: #800080 } /* Literal.String.Interpol */
+.highlight .sx { color: #800080 } /* Literal.String.Other */
+.highlight .sr { color: #800080 } /* Literal.String.Regex */
+.highlight .s1 { color: #800080 } /* Literal.String.Single */
+.highlight .ss { color: #800080 } /* Literal.String.Symbol */
+.highlight .bp { color: #2c2cff } /* Name.Builtin.Pseudo */
+.highlight .fm { font-weight: bold; font-style: italic } /* Name.Function.Magic */
+.highlight .vc { color: #2c2cff; font-weight: bold } /* Name.Variable.Class */
+.highlight .vg { color: #2c2cff; font-weight: bold } /* Name.Variable.Global */
+.highlight .vi { color: #2c2cff; font-weight: bold } /* Name.Variable.Instance */
+.highlight .vm { color: #2c2cff; font-weight: bold } /* Name.Variable.Magic */
+.highlight .il { color: #2c8553; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -5,62 +5,64 @@ td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5
 span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
 .highlight { background: #ffffff; }
-.highlight .c { color: #008800; font-style: italic } /* Comment */
-.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight .g { color: #2c2cff } /* Generic */
-.highlight .k { color: #2c2cff } /* Keyword */
-.highlight .x { background-color: #ffffe0 } /* Other */
-.highlight .ch { color: #008800; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #008800; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #008800; font-style: italic } /* Comment.Preproc */
-.highlight .cpf { color: #008800; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #008800; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #008800; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #2c2cff } /* Generic.Deleted */
-.highlight .ge { color: #008800 } /* Generic.Emph */
-.highlight .gr { color: #d30202 } /* Generic.Error */
-.highlight .gh { color: #2c2cff } /* Generic.Heading */
-.highlight .gi { color: #2c2cff } /* Generic.Inserted */
-.highlight .go { color: #2c2cff } /* Generic.Output */
-.highlight .gp { color: #2c2cff } /* Generic.Prompt */
-.highlight .gs { color: #2c2cff } /* Generic.Strong */
-.highlight .gu { color: #2c2cff } /* Generic.Subheading */
-.highlight .gt { color: #2c2cff } /* Generic.Traceback */
-.highlight .kc { color: #2c2cff; font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: #2c2cff } /* Keyword.Declaration */
-.highlight .kn { color: #2c2cff } /* Keyword.Namespace */
-.highlight .kp { color: #2c2cff } /* Keyword.Pseudo */
-.highlight .kr { color: #353580; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #2c2cff } /* Keyword.Type */
-.highlight .m { color: #2c8553; font-weight: bold } /* Literal.Number */
-.highlight .s { color: #800080 } /* Literal.String */
-.highlight .n { color: #2c2c2c }
-.highlight .nb { color: #2c2cff } /* Name.Builtin */
-.highlight .nf { color: #2c2c2c; font-weight: bold; font-style: italic } /* Name.Function */
-.highlight .nv { color: #2c2cff; font-weight: bold } /* Name.Variable */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mb { color: #2c8553; font-weight: bold } /* Literal.Number.Bin */
-.highlight .mf { color: #2c8553; font-weight: bold } /* Literal.Number.Float */
-.highlight .mh { color: #2c8553; font-weight: bold } /* Literal.Number.Hex */
-.highlight .mi { color: #2c8553; font-weight: bold } /* Literal.Number.Integer */
-.highlight .mo { color: #2c8553; font-weight: bold } /* Literal.Number.Oct */
-.highlight .sa { color: #800080 } /* Literal.String.Affix */
-.highlight .sb { color: #800080 } /* Literal.String.Backtick */
-.highlight .sc { color: #800080 } /* Literal.String.Char */
-.highlight .dl { color: #800080 } /* Literal.String.Delimiter */
-.highlight .sd { color: #800080 } /* Literal.String.Doc */
-.highlight .s2 { color: #800080 } /* Literal.String.Double */
-.highlight .se { color: #800080 } /* Literal.String.Escape */
-.highlight .sh { color: #800080 } /* Literal.String.Heredoc */
-.highlight .si { color: #800080 } /* Literal.String.Interpol */
-.highlight .sx { color: #800080 } /* Literal.String.Other */
-.highlight .sr { color: #800080 } /* Literal.String.Regex */
-.highlight .s1 { color: #800080 } /* Literal.String.Single */
-.highlight .ss { color: #800080 } /* Literal.String.Symbol */
-.highlight .bp { color: #2c2cff } /* Name.Builtin.Pseudo */
-.highlight .fm { font-weight: bold; font-style: italic } /* Name.Function.Magic */
-.highlight .vc { color: #2c2cff; font-weight: bold } /* Name.Variable.Class */
-.highlight .vg { color: #2c2cff; font-weight: bold } /* Name.Variable.Global */
-.highlight .vi { color: #2c2cff; font-weight: bold } /* Name.Variable.Instance */
-.highlight .vm { color: #2c2cff; font-weight: bold } /* Name.Variable.Magic */
-.highlight .il { color: #2c8553; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight .c { color: #177500;  font-style: italic } /* Comment */
+.highlight .err { color: #000000 } /* Error */
+.highlight .k { color: #A90D91 } /* Keyword */
+.highlight .l { color: #1C01CE } /* Literal */
+.highlight .n { color: #000000 } /* Name */
+.highlight .o { color: #000000 } /* Operator */
+.highlight .ch { color: #177500 } /* Comment.Hashbang */
+.highlight .cm { color: #177500;  font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #633820 } /* Comment.Preproc */
+.highlight .cpf { color: #177500 } /* Comment.PreprocFile */
+.highlight .c1 { color: #177500;  font-style: italic } /* Comment.Single */
+.highlight .cs { color: #177500;  font-style: italic } /* Comment.Special */
+.highlight .kc { color: #A90D91 } /* Keyword.Constant */
+.highlight .kd { color: #A90D91 } /* Keyword.Declaration */
+.highlight .kn { color: #A90D91 } /* Keyword.Namespace */
+.highlight .kp { color: #A90D91 } /* Keyword.Pseudo */
+.highlight .kr { color: #A90D91 } /* Keyword.Reserved */
+.highlight .kt { color: #A90D91 } /* Keyword.Type */
+.highlight .ld { color: #1C01CE } /* Literal.Date */
+.highlight .m { color: #1C01CE } /* Literal.Number */
+.highlight .s { color: #C41A16 } /* Literal.String */
+.highlight .na { color: #836C28 } /* Name.Attribute */
+.highlight .nb { color: #A90D91 } /* Name.Builtin */
+.highlight .nc { color: #3F6E75 } /* Name.Class */
+.highlight .no { color: #000000 } /* Name.Constant */
+.highlight .nd { color: #000000 } /* Name.Decorator */
+.highlight .ni { color: #000000 } /* Name.Entity */
+.highlight .ne { color: #000000 } /* Name.Exception */
+.highlight .nf { color: #000000 } /* Name.Function */
+.highlight .nl { color: #000000 } /* Name.Label */
+.highlight .nn { color: #000000 } /* Name.Namespace */
+.highlight .nx { color: #000000 } /* Name.Other */
+.highlight .py { color: #000000 } /* Name.Property */
+.highlight .nt { color: #000000 } /* Name.Tag */
+.highlight .nv { color: #000000 } /* Name.Variable */
+.highlight .ow { color: #000000 } /* Operator.Word */
+.highlight .mb { color: #1C01CE } /* Literal.Number.Bin */
+.highlight .mf { color: #1C01CE } /* Literal.Number.Float */
+.highlight .mh { color: #1C01CE } /* Literal.Number.Hex */
+.highlight .mi { color: #1C01CE } /* Literal.Number.Integer */
+.highlight .mo { color: #1C01CE } /* Literal.Number.Oct */
+.highlight .sa { color: #C41A16 } /* Literal.String.Affix */
+.highlight .sb { color: #C41A16 } /* Literal.String.Backtick */
+.highlight .sc { color: #2300CE } /* Literal.String.Char */
+.highlight .dl { color: #C41A16 } /* Literal.String.Delimiter */
+.highlight .sd { color: #C41A16 } /* Literal.String.Doc */
+.highlight .s2 { color: #C41A16 } /* Literal.String.Double */
+.highlight .se { color: #C41A16 } /* Literal.String.Escape */
+.highlight .sh { color: #C41A16 } /* Literal.String.Heredoc */
+.highlight .si { color: #C41A16 } /* Literal.String.Interpol */
+.highlight .sx { color: #C41A16 } /* Literal.String.Other */
+.highlight .sr { color: #C41A16 } /* Literal.String.Regex */
+.highlight .s1 { color: #C41A16 } /* Literal.String.Single */
+.highlight .ss { color: #C41A16 } /* Literal.String.Symbol */
+.highlight .bp { color: #5B269A } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #000000 } /* Name.Function.Magic */
+.highlight .vc { color: #000000 } /* Name.Variable.Class */
+.highlight .vg { color: #000000 } /* Name.Variable.Global */
+.highlight .vi { color: #000000 } /* Name.Variable.Instance */
+.highlight .vm { color: #000000 } /* Name.Variable.Magic */
+.highlight .il { color: #1C01CE } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
Mostly `code`/`pre`/`tt` blocks needed a font-size of 85% and I wanted a completely different Pygments stylesheet (which itself led to [a whole different rabbit hole](https://github.com/numist/pygments-css))

Fixes #2